### PR TITLE
Add option for stable translation display

### DIFF
--- a/src/Translator.cs
+++ b/src/Translator.cs
@@ -208,7 +208,8 @@ namespace LiveCaptionsTranslator
                 }
                 else if (!string.IsNullOrEmpty(RegexPatterns.NoticePrefix().Replace(
                              translatedText, string.Empty).Trim()) &&
-                         string.CompareOrdinal(Caption.TranslatedCaption, translatedText) != 0)
+                         string.CompareOrdinal(Caption.TranslatedCaption, translatedText) != 0 &&
+                         (!Setting.MainWindow.StableTranslationOnly || isChoke))
                 {
                     // Main page
                     Caption.TranslatedCaption = translatedText;

--- a/src/models/TranslationTaskQueue.cs
+++ b/src/models/TranslationTaskQueue.cs
@@ -42,13 +42,16 @@ namespace LiveCaptionsTranslator.models
             }
             
             output = translationTask.Task.Result;
-            var translatedText = output.Item1;
-            
+            var (translatedText, isChoke) = output;
+
             // Log after translation.
             bool isOverwrite = await Translator.IsOverwrite(translationTask.OriginalText);
-            if (!isOverwrite)
-                await Translator.AddLogCard();
-            await Translator.Log(translationTask.OriginalText, translatedText, isOverwrite);
+            if (!Translator.Setting.MainWindow.StableTranslationOnly || isChoke)
+            {
+                if (!isOverwrite)
+                    await Translator.AddLogCard();
+                await Translator.Log(translationTask.OriginalText, translatedText, isOverwrite);
+            }
         }
     }
 

--- a/src/models/WindowState.cs
+++ b/src/models/WindowState.cs
@@ -11,6 +11,7 @@ namespace LiveCaptionsTranslator.models
         private bool captionLogEnabled = false;
         private int captionLogMax = 2;
         private bool latencyShow = false;
+        private bool stableTranslationOnly = false;
 
         public bool Topmost
         {
@@ -46,6 +47,15 @@ namespace LiveCaptionsTranslator.models
             {
                 latencyShow = value;
                 OnPropertyChanged("LatencyShow");
+            }
+        }
+        public bool StableTranslationOnly
+        {
+            get => stableTranslationOnly;
+            set
+            {
+                stableTranslationOnly = value;
+                OnPropertyChanged("StableTranslationOnly");
             }
         }
 

--- a/src/pages/SettingPage.xaml
+++ b/src/pages/SettingPage.xaml
@@ -191,6 +191,16 @@
                     OffContent="Off"
                     OnContent="On" />
             </StackPanel>
+            <StackPanel Margin="15,10,0,0" Orientation="Vertical">
+                <TextBlock Margin="2.5,0,0,5" Text="Stable Only" />
+                <ui:ToggleSwitch
+                    Width="100"
+                    Height="30"
+                    Padding="10,4,10,7"
+                    IsChecked="{Binding MainWindow.StableTranslationOnly, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                    OffContent="Off"
+                    OnContent="On" />
+            </StackPanel>
         </StackPanel>
 
         <StackPanel Grid.Column="3" Orientation="Vertical">


### PR DESCRIPTION
## Summary
- add `StableTranslationOnly` setting
- update settings page UI with toggle
- update display logic to only refresh when a sentence finishes
- avoid logging partial translations when the option is enabled

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ad85964f8832ebe7c39a461a72cca