### PR TITLE
Fix page count calculation in history loader

### DIFF
--- a/src/utils/HistoryLogger.cs
+++ b/src/utils/HistoryLogger.cs
@@ -86,12 +86,13 @@ namespace LiveCaptionsTranslator.utils
         {
             var history = new List<TranslationHistoryEntry>();
             int maxPage = 1;
-            using (var command = new SqliteCommand(@$"SELECT COUNT() AS maxPage
+            using (var command = new SqliteCommand(@$"SELECT COUNT(*)
                 FROM TranslationHistory
                 WHERE SourceText LIKE '%{searchText}%' OR TranslatedText LIKE '%{searchText}%'",
                 GetConnection()))
             {
-                maxPage = Convert.ToInt32(await command.ExecuteScalarAsync(token)) / maxRow;
+                int totalCount = Convert.ToInt32(await command.ExecuteScalarAsync(token));
+                maxPage = (totalCount + maxRow - 1) / maxRow;
             }
 
             using (var command = new SqliteCommand(@$"


### PR DESCRIPTION
## Summary
- correct history pagination math when fetching entries from the SQLite database

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ad69499d0832eb55e414b5adc3a16